### PR TITLE
Created Endpoint: create_team_after_judge

### DIFF
--- a/emdcbackend/emdcbackend/urls.py
+++ b/emdcbackend/emdcbackend/urls.py
@@ -64,7 +64,7 @@ urlpatterns = [
     # Teams
     path('api/team/get/<int:team_id>/', team_by_id, name='team_by_id'),
     path('api/team/create/', create_team, name='create_team'),
-    # path('api/team/createAfterJudge/', create_team_after_judge, name='create_team_after_judge'),
+    path('api/team/createAfterJudge/', create_team_after_judge, name='create_team_after_judge'),
     path('api/team/edit/', edit_team, name='edit_team'),
     path('api/team/delete/<int:team_id>/', delete_team_by_id, name='delete_team_by_id'),
     path('api/team/rankedteams/', get_teams_by_team_rank, name='get_teams_by_team_rank'),

--- a/emdcbackend/emdcbackend/views/Maps/MapClusterToJudge.py
+++ b/emdcbackend/emdcbackend/views/Maps/MapClusterToJudge.py
@@ -79,7 +79,7 @@ def map_cluster_to_judge(map_data):
     else:
         raise ValidationError(serializer.errors)
     
-def judges_by_cluster_id_nonhttp(cluster_id):
+def judges_by_cluster(cluster_id):
     mappings = MapJudgeToCluster.objects.filter(clusterid=cluster_id)
     judge_ids = mappings.values_list('judgeid', flat=True)
     judges = Judge.objects.filter(id__in=judge_ids)

--- a/emdcbackend/emdcbackend/views/judge.py
+++ b/emdcbackend/emdcbackend/views/judge.py
@@ -90,6 +90,7 @@ def edit_judge(request):
         judge = get_object_or_404(Judge, id=request.data["id"])
         new_first_name = request.data["first_name"]
         new_last_name = request.data["last_name"]
+        new_phone_number = request.data["phone_number"]
         new_presentation = request.data["presentation"]
         new_mdo = request.data["mdo"]
         new_journal = request.data["journal"]
@@ -105,6 +106,8 @@ def edit_judge(request):
                 judge.first_name = new_first_name
             if new_last_name != judge.last_name:
                 judge.last_name = new_last_name
+            if new_phone_number != judge.phone_number:
+                judge.phone_number = new_phone_number
 
             # if the judge is being moved to a new cluster
             if clusterid != new_cluster:

--- a/emdcbackend/emdcbackend/views/scoresheets.py
+++ b/emdcbackend/emdcbackend/views/scoresheets.py
@@ -384,11 +384,6 @@ def make_sheets_for_team(teamid, clusterid):
                 })
             else:
                 raise ValidationError(map_serializer.errors)
-            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PRESENTATION, isSubmitted=False)
-            # MapScoresheetToTeamJudge.objects.create(
-            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PRESENTATION
-            # )
-            # created_score_sheets.append(score_sheet)
         if judge.journal:
             sheet = create_base_score_sheet(2)
             map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 2}
@@ -403,11 +398,6 @@ def make_sheets_for_team(teamid, clusterid):
                 })
             else:
                 raise ValidationError(map_serializer.errors)
-            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.JOURNAL, isSubmitted=False)
-            # MapScoresheetToTeamJudge.objects.create(
-            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.JOURNAL
-            # )
-            # created_score_sheets.append(score_sheet)
         if judge.mdo:
             sheet = create_base_score_sheet(3)
             map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 3}
@@ -422,11 +412,6 @@ def make_sheets_for_team(teamid, clusterid):
                 })
             else:
                 raise ValidationError(map_serializer.errors)
-            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.MACHINEDESIGN, isSubmitted=False)
-            # MapScoresheetToTeamJudge.objects.create(
-            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.MACHINEDESIGN
-            # )
-            # created_score_sheets.append(score_sheet)
         if judge.penalties:
             sheet = create_base_score_sheet_penalties()
             map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 4}
@@ -441,11 +426,6 @@ def make_sheets_for_team(teamid, clusterid):
                 })
             else:
                 raise ValidationError(map_serializer.errors)
-            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PENALTIES, isSubmitted=False)
-            # MapScoresheetToTeamJudge.objects.create(
-            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PENALTIES
-            # )
-            # created_score_sheets.append(score_sheet)
 
     return created_score_sheets
 

--- a/emdcbackend/emdcbackend/views/scoresheets.py
+++ b/emdcbackend/emdcbackend/views/scoresheets.py
@@ -363,36 +363,36 @@ def delete_sheets_for_teams_in_cluster(judge_id, cluster_id, penalties, presenta
     except Exception as e:
         raise ValidationError({"detail": str(e)})
     
-# def create_score_sheets_for_team_nonhttp(team, clusterid):
-#     created_score_sheets = []
-#     judges = MapJudgeToCluster.objects.filter(clusterid=clusterid)
-#     for judge in judges:
-#         # Create score sheets for each type (Presentation, Journal, Machine Design, Penalties) based on the judge's role
-#         if judge.presentation:
-#             score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PRESENTATION, isSubmitted=False)
-#             MapScoresheetToTeamJudge.objects.create(
-#                 teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PRESENTATION
-#             )
-#             created_score_sheets.append(score_sheet)
-#         if judge.journal:
-#             score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.JOURNAL, isSubmitted=False)
-#             MapScoresheetToTeamJudge.objects.create(
-#                 teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.JOURNAL
-#             )
-#             created_score_sheets.append(score_sheet)
-#         if judge.mdo:
-#             score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.MACHINEDESIGN, isSubmitted=False)
-#             MapScoresheetToTeamJudge.objects.create(
-#                 teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.MACHINEDESIGN
-#             )
-#             created_score_sheets.append(score_sheet)
-#         if judge.penalties:
-#             score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PENALTIES, isSubmitted=False)
-#             MapScoresheetToTeamJudge.objects.create(
-#                 teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PENALTIES
-#             )
-#             created_score_sheets.append(score_sheet)
-#         return created_score_sheets
+def create_score_sheets_for_team_nonhttp(team, clusterid):
+    created_score_sheets = []
+    judges = MapJudgeToCluster.objects.filter(clusterid=clusterid)
+    for judge in judges:
+        # Create score sheets for each type (Presentation, Journal, Machine Design, Penalties) based on the judge's role
+        if judge.presentation:
+            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PRESENTATION, isSubmitted=False)
+            MapScoresheetToTeamJudge.objects.create(
+                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PRESENTATION
+            )
+            created_score_sheets.append(score_sheet)
+        if judge.journal:
+            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.JOURNAL, isSubmitted=False)
+            MapScoresheetToTeamJudge.objects.create(
+                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.JOURNAL
+            )
+            created_score_sheets.append(score_sheet)
+        if judge.mdo:
+            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.MACHINEDESIGN, isSubmitted=False)
+            MapScoresheetToTeamJudge.objects.create(
+                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.MACHINEDESIGN
+            )
+            created_score_sheets.append(score_sheet)
+        if judge.penalties:
+            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PENALTIES, isSubmitted=False)
+            MapScoresheetToTeamJudge.objects.create(
+                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PENALTIES
+            )
+            created_score_sheets.append(score_sheet)
+        return created_score_sheets
 
 
 @api_view(["GET"])

--- a/emdcbackend/emdcbackend/views/scoresheets.py
+++ b/emdcbackend/emdcbackend/views/scoresheets.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from django.shortcuts import get_object_or_404
 from rest_framework.exceptions import ValidationError
 from .Maps.MapScoreSheet import delete_score_sheet_mapping
-from ..models import Scoresheet, Teams, MapClusterToTeam, MapScoresheetToTeamJudge, MapJudgeToCluster, ScoresheetEnum
+from ..models import Scoresheet, Teams, Judge, MapClusterToTeam, MapScoresheetToTeamJudge, MapJudgeToCluster, ScoresheetEnum
 from ..serializers import ScoresheetSerializer, MapScoreSheetToTeamJudgeSerializer
 
 @api_view(["GET"])
@@ -362,37 +362,92 @@ def delete_sheets_for_teams_in_cluster(judge_id, cluster_id, penalties, presenta
 
     except Exception as e:
         raise ValidationError({"detail": str(e)})
-    
-def make_sheets_for_team(team, clusterid):
+  
+def make_sheets_for_team(teamid, clusterid):
     created_score_sheets = []
-    judges = MapJudgeToCluster.objects.filter(clusterid=clusterid)
-    for judge in judges:
+    judges = MapJudgeToCluster.objects.filter(clusterid=clusterid)  # get list of judge mappings
+    for judge_map in judges:
         # Create score sheets for each type (Presentation, Journal, Machine Design, Penalties) based on the judge's role
+        judge = Judge.objects.get(id=judge_map.judgeid)  # get judge from judge mapping
+
         if judge.presentation:
-            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PRESENTATION, isSubmitted=False)
-            MapScoresheetToTeamJudge.objects.create(
-                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PRESENTATION
-            )
-            created_score_sheets.append(score_sheet)
+            sheet = create_base_score_sheet(1)
+            map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 1}
+            map_serializer = MapScoreSheetToTeamJudgeSerializer(data=map_data)
+            if map_serializer.is_valid():
+                map_serializer.save()
+                created_score_sheets.append({
+                    "team_id": teamid,
+                    "judge_id": judge.id,
+                    "scoresheet_id": sheet.get('id'),
+                    "sheetType": 1
+                })
+            else:
+                raise ValidationError(map_serializer.errors)
+            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PRESENTATION, isSubmitted=False)
+            # MapScoresheetToTeamJudge.objects.create(
+            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PRESENTATION
+            # )
+            # created_score_sheets.append(score_sheet)
         if judge.journal:
-            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.JOURNAL, isSubmitted=False)
-            MapScoresheetToTeamJudge.objects.create(
-                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.JOURNAL
-            )
-            created_score_sheets.append(score_sheet)
+            sheet = create_base_score_sheet(2)
+            map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 2}
+            map_serializer = MapScoreSheetToTeamJudgeSerializer(data=map_data)
+            if map_serializer.is_valid():
+                map_serializer.save()
+                created_score_sheets.append({
+                    "team_id": teamid,
+                    "judge_id": judge.id,
+                    "scoresheet_id": sheet.get('id'),
+                    "sheetType": 2
+                })
+            else:
+                raise ValidationError(map_serializer.errors)
+            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.JOURNAL, isSubmitted=False)
+            # MapScoresheetToTeamJudge.objects.create(
+            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.JOURNAL
+            # )
+            # created_score_sheets.append(score_sheet)
         if judge.mdo:
-            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.MACHINEDESIGN, isSubmitted=False)
-            MapScoresheetToTeamJudge.objects.create(
-                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.MACHINEDESIGN
-            )
-            created_score_sheets.append(score_sheet)
+            sheet = create_base_score_sheet(3)
+            map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 3}
+            map_serializer = MapScoreSheetToTeamJudgeSerializer(data=map_data)
+            if map_serializer.is_valid():
+                map_serializer.save()
+                created_score_sheets.append({
+                    "team_id": teamid,
+                    "judge_id": judge.id,
+                    "scoresheet_id": sheet.get('id'),
+                    "sheetType": 3
+                })
+            else:
+                raise ValidationError(map_serializer.errors)
+            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.MACHINEDESIGN, isSubmitted=False)
+            # MapScoresheetToTeamJudge.objects.create(
+            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.MACHINEDESIGN
+            # )
+            # created_score_sheets.append(score_sheet)
         if judge.penalties:
-            score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PENALTIES, isSubmitted=False)
-            MapScoresheetToTeamJudge.objects.create(
-                teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PENALTIES
-            )
-            created_score_sheets.append(score_sheet)
-        return created_score_sheets
+            sheet = create_base_score_sheet_penalties()
+            map_data = {"teamid": teamid, "judgeid": judge.id, "scoresheetid": sheet.get('id'), "sheetType": 4}
+            map_serializer = MapScoreSheetToTeamJudgeSerializer(data=map_data)
+            if map_serializer.is_valid():
+                map_serializer.save()
+                created_score_sheets.append({
+                    "team_id": teamid,
+                    "judge_id": judge.id,
+                    "scoresheet_id": sheet.get('id'),
+                    "sheetType": 4
+                })
+            else:
+                raise ValidationError(map_serializer.errors)
+            # score_sheet = Scoresheet.objects.create(sheetType=ScoresheetEnum.PENALTIES, isSubmitted=False)
+            # MapScoresheetToTeamJudge.objects.create(
+            #     teamid=team.id, judgeid=judge.id, scoresheetid=score_sheet.id, sheetType=ScoresheetEnum.PENALTIES
+            # )
+            # created_score_sheets.append(score_sheet)
+
+    return created_score_sheets
 
 
 @api_view(["GET"])

--- a/emdcbackend/emdcbackend/views/scoresheets.py
+++ b/emdcbackend/emdcbackend/views/scoresheets.py
@@ -363,7 +363,7 @@ def delete_sheets_for_teams_in_cluster(judge_id, cluster_id, penalties, presenta
     except Exception as e:
         raise ValidationError({"detail": str(e)})
     
-def create_score_sheets_for_team_nonhttp(team, clusterid):
+def make_sheets_for_team(team, clusterid):
     created_score_sheets = []
     judges = MapJudgeToCluster.objects.filter(clusterid=clusterid)
     for judge in judges:

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -1,7 +1,7 @@
 from ..models import Teams, Scoresheet, Judge, JudgeClusters, MapScoresheetToTeamJudge, MapContestToTeam
 from .Maps import MapScoreSheet
 from .coach import create_coach, create_user_and_coach, get_coach
-from .scoresheets import create_score_sheets_for_team#, create_score_sheets_for_team_nonhttp
+from .scoresheets import create_score_sheets_for_team, create_score_sheets_for_team_nonhttp
 from ..serializers import TeamSerializer
 from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
 from .Maps.MapCoachToTeam import create_coach_to_team_map
@@ -23,8 +23,8 @@ from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
 from .Maps.MapCoachToTeam import create_coach_to_team_map
 from .Maps.MapContestToTeam import create_team_to_contest_map
 from .Maps.MapClusterToTeam import create_team_to_cluster_map
-# from .Maps.MapClusterToJudge import judges_by_cluster_id, judges_by_cluster_id_nonhttp
-# from .Maps.MapScoreSheet import map_score_sheet
+from .Maps.MapClusterToJudge import judges_by_cluster_id, judges_by_cluster_id_nonhttp
+from .Maps.MapScoreSheet import map_score_sheet
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 
@@ -194,36 +194,80 @@ def get_teams_by_team_rank(request):
     serializer = TeamSerializer(teams, many=True)
     return Response({"Teams": serializer.data}, status=status.HTTP_200_OK)
 
-# @api_view(["POST"])
-# @authentication_classes([SessionAuthentication, TokenAuthentication])
-# @permission_classes([IsAuthenticated])
-# def create_team_after_judge(request):
-#   try:
-#     with transaction.atomic():
-#       # create team object.
-#       team_response = make_team(request.data)
+@api_view(["POST"])
+@authentication_classes([SessionAuthentication, TokenAuthentication])
+@permission_classes([IsAuthenticated])
+def create_team_after_judge(request):
+  try:
+    with transaction.atomic():
+      # create team object.
+      team_response = make_team(request.data)
       
-#       try:
-#         user = User.objects.get(username=request.data["username"])
+      try:
+        user = User.objects.get(username=request.data["username"])
         
-#         role_mapping_response = get_role_mapping(user.id)
-#         if role_mapping_response.get("id"):
-#           # if we have the mapping and it matches, we get the coach from the mapping
-#           if role_mapping_response.get("role") == 4:
-#             coach_response = get_coach(role_mapping_response.get("relatedid"))
-#           else:
-#             raise ValidationError({"detail": "This user is already mapped to a role."})
-#         else:
-#           coach_response = create_coach(request.data)
-#           role_mapping_response = create_user_role_map({
-#             "uuid": user.id,
-#             "role": 4,
-#             "relatedid": coach_response.get("id")
-#             })
-#       except:
-#         user_response, coach_response = create_user_and_coach(request.data)
-#         role_mapping_response = create_user_role_map({
-#             "uuid": user_response.get("user").get("id"),
-#             "role": 4,
-#             "relatedid": coach_response.get("id")
-#             })
+        role_mapping_response = get_role_mapping(user.id)
+        if role_mapping_response.get("id"):
+          # if we have the mapping and it matches, we get the coach from the mapping
+          if role_mapping_response.get("role") == 4:
+            coach_response = get_coach(role_mapping_response.get("relatedid"))
+          else:
+            raise ValidationError({"detail": "This user is already mapped to a role."})
+        else:
+          coach_response = create_coach(request.data)
+          role_mapping_response = create_user_role_map({
+            "uuid": user.id,
+            "role": 4,
+            "relatedid": coach_response.get("id")
+            })
+      except:
+        user_response, coach_response = create_user_and_coach(request.data)
+        role_mapping_response = create_user_role_map({
+            "uuid": user_response.get("user").get("id"),
+            "role": 4,
+            "relatedid": coach_response.get("id")
+            })
+        
+      responses = [
+        # map team to coach, map team to contest, map team to cluster, create score sheets for team
+        create_coach_to_team_map({
+          "teamid": team_response.get("id"),
+          "coachid": coach_response.get("id")
+        }),
+        create_team_to_contest_map({
+          "contestid": request.data["contestid"],
+          "teamid": team_response.get("id")
+        }),
+        create_team_to_cluster_map({
+          "clusterid": request.data["clusterid"],
+          "teamid": team_response.get("id")
+        }),
+        create_score_sheets_for_team_nonhttp({  # create score sheets for all judges in cluster and map them
+          "teamid": team_response.get("id"),
+          "clusterid": request.data["clusterid"]
+        })
+        # map_score_sheet({  # map all created score sheets to judges in the cluster
+        #   "judgeid": request.data["judgeid"],
+        #   "teamid": team_response.get("id"),
+        #   "sheetType": "journal"
+        # })
+      ]
+
+      for response in responses:
+        if isinstance(response, Response):
+          return response
+        
+      return Response({
+        "team":team_response,
+        "coach":coach_response,
+        "coach to team map": responses[0],
+        "team to contest map": responses[1],
+        "team to cluster map": responses[2],
+        "score sheets": responses[3],
+      },status=status.HTTP_201_CREATED)
+    
+  except ValidationError as e:  # Catching ValidationErrors specifically
+    return Response({"errors": e.detail}, status=status.HTTP_400_BAD_REQUEST)
+  
+  except Exception as e:
+    return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -1,7 +1,7 @@
 from ..models import Teams, Scoresheet, Judge, JudgeClusters, MapScoresheetToTeamJudge, MapContestToTeam
 from .Maps import MapScoreSheet
 from .coach import create_coach, create_user_and_coach, get_coach
-from .scoresheets import create_score_sheets_for_team, create_score_sheets_for_team_nonhttp
+from .scoresheets import create_score_sheets_for_team, make_sheets_for_team
 from ..serializers import TeamSerializer
 from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
 from .Maps.MapCoachToTeam import create_coach_to_team_map
@@ -23,7 +23,7 @@ from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
 from .Maps.MapCoachToTeam import create_coach_to_team_map
 from .Maps.MapContestToTeam import create_team_to_contest_map
 from .Maps.MapClusterToTeam import create_team_to_cluster_map
-from .Maps.MapClusterToJudge import judges_by_cluster_id, judges_by_cluster_id_nonhttp
+from .Maps.MapClusterToJudge import judges_by_cluster_id, judges_by_cluster
 from .Maps.MapScoreSheet import map_score_sheet
 from django.shortcuts import get_object_or_404
 from django.db import transaction

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -242,15 +242,10 @@ def create_team_after_judge(request):
           "clusterid": request.data["clusterid"],
           "teamid": team_response.get("id")
         }),
-        create_score_sheets_for_team_nonhttp({  # create score sheets for all judges in cluster and map them
-          "teamid": team_response.get("id"),
-          "clusterid": request.data["clusterid"]
-        })
-        # map_score_sheet({  # map all created score sheets to judges in the cluster
-        #   "judgeid": request.data["judgeid"],
-        #   "teamid": team_response.get("id"),
-        #   "sheetType": "journal"
-        # })
+        make_sheets_for_team(  # create score sheets for all judges in cluster and map them
+          teamid=team_response.get("id"),
+          clusterid=request.data["clusterid"]
+        )
       ]
 
       for response in responses:

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -1,9 +1,8 @@
-from ..models import Teams, Scoresheet, Judge, JudgeClusters, MapScoresheetToTeamJudge, MapContestToTeam
-from .Maps import MapScoreSheet
+from ..models import Teams, Scoresheet, JudgeClusters, MapScoresheetToTeamJudge, MapContestToTeam
 from .coach import create_coach, create_user_and_coach, get_coach
 from .scoresheets import create_score_sheets_for_team, make_sheets_for_team
 from ..serializers import TeamSerializer
-from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
+from .Maps.MapUserToRole import get_role_mapping, create_user_role_map
 from .Maps.MapCoachToTeam import create_coach_to_team_map
 from .Maps.MapContestToTeam import create_team_to_contest_map
 from .Maps.MapClusterToTeam import create_team_to_cluster_map
@@ -14,17 +13,10 @@ from rest_framework.decorators import (
     permission_classes,
 )
 from rest_framework.exceptions import ValidationError
-from django.contrib.auth.models import User
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
-from ..serializers import TeamSerializer
-from .Maps.MapUserToRole import get_role, get_role_mapping, create_user_role_map
-from .Maps.MapCoachToTeam import create_coach_to_team_map
-from .Maps.MapContestToTeam import create_team_to_contest_map
-from .Maps.MapClusterToTeam import create_team_to_cluster_map
-from .Maps.MapClusterToJudge import judges_by_cluster_id, judges_by_cluster
-from .Maps.MapScoreSheet import map_score_sheet
+from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 


### PR DESCRIPTION
Added an endpoint that will create a team after judges in the team's given cluster are created, and create base scoresheets for said team according to each judges' roles.