### PR TITLE
Cascaded delete team endpoint

### DIFF
--- a/emdcbackend/emdcbackend/views/judge.py
+++ b/emdcbackend/emdcbackend/views/judge.py
@@ -189,7 +189,6 @@ def delete_judge(request, judge_id):
         cluster_mapping = MapJudgeToCluster.objects.get(judgeid=judge_id)
         teams_mappings = MapScoresheetToTeamJudge.objects.filter(judgeid=judge_id)
         contest_mapping = MapContestToJudge.objects.filter(judgeid=judge_id)
-        # scoresheet_team_judge = MapScoresheetToTeamJudge.objects.filter(judgeid=judge_id)
 
         # delete associataed user
         user.delete()

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -237,8 +237,9 @@ def delete_team_by_id(request, team_id):
         scoresheet_ids = scoresheet_mappings.values_list('scoresheetid', flat=True)
         scoresheets = Scoresheet.objects.filter(id__in=scoresheet_ids)
         coach_mapping = MapCoachToTeam.objects.get(teamid=team_id)
-        judge_mappings = MapJudgeToCluster.objects.filter(clusterid__in=MapClusterToTeam.objects.filter(teamid=team_id).values_list('clusterid', flat=True))
+        judge_mappings = 
         cluster_mappings = MapClusterToTeam.objects.filter(teamid=team_id)
+        contest_mapping = MapContestToTeam.objects.get(teamid=team_id)
 
         # delete associated scoresheets
         for scoresheet in scoresheets:
@@ -248,12 +249,15 @@ def delete_team_by_id(request, team_id):
         coach_mapping.delete()
 
         # delete judge-team mappings
-        for mapping in judge_mappings:
+        for mapping in judge_mappings:  # Fix: somehow the judge-cluster mapping is also being deleted
             mapping.delete()
 
-        # delete cluster-team mapping
+        # delete cluster-team mappings (judge cluster and all teams cluster)
         for mapping in cluster_mappings:
             mapping.delete()
+
+        # delete contest-team mapping
+        contest_mapping.delete()
 
         # Delete team
         team.delete()

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -238,7 +238,7 @@ def delete_team_by_id(request, team_id):
         scoresheets = Scoresheet.objects.filter(id__in=scoresheet_ids)
         coach_mapping = MapCoachToTeam.objects.get(teamid=team_id)
         judge_mappings = MapJudgeToCluster.objects.filter(clusterid__in=MapClusterToTeam.objects.filter(teamid=team_id).values_list('clusterid', flat=True))
-        cluster_mapping = MapClusterToTeam.objects.get(teamid=team_id)
+        cluster_mappings = MapClusterToTeam.objects.filter(teamid=team_id)
 
         # delete associated scoresheets
         for scoresheet in scoresheets:
@@ -252,7 +252,8 @@ def delete_team_by_id(request, team_id):
             mapping.delete()
 
         # delete cluster-team mapping
-        cluster_mapping.delete()
+        for mapping in cluster_mappings:
+            mapping.delete()
 
         # Delete team
         team.delete()

--- a/emdcbackend/emdcbackend/views/team.py
+++ b/emdcbackend/emdcbackend/views/team.py
@@ -237,7 +237,6 @@ def delete_team_by_id(request, team_id):
         scoresheet_ids = scoresheet_mappings.values_list('scoresheetid', flat=True)
         scoresheets = Scoresheet.objects.filter(id__in=scoresheet_ids)
         coach_mapping = MapCoachToTeam.objects.get(teamid=team_id)
-        judge_mappings = 
         cluster_mappings = MapClusterToTeam.objects.filter(teamid=team_id)
         contest_mapping = MapContestToTeam.objects.get(teamid=team_id)
 
@@ -248,8 +247,8 @@ def delete_team_by_id(request, team_id):
         # delete coach-team mapping
         coach_mapping.delete()
 
-        # delete judge-team mappings
-        for mapping in judge_mappings:  # Fix: somehow the judge-cluster mapping is also being deleted
+        # delete scoresheet-team-judge mappings
+        for mapping in scoresheet_mappings:
             mapping.delete()
 
         # delete cluster-team mappings (judge cluster and all teams cluster)


### PR DESCRIPTION
Updated the delete team endpoint to where it would also delete the associated mappings and scoresheets along with the team.